### PR TITLE
Fix for changed output of BB in GeoSteiner v5.0.1

### DIFF
--- a/geonet/geosteiner.py
+++ b/geonet/geosteiner.py
@@ -15,7 +15,7 @@ def geosteiner(pos):
     def parse_ps(output):
         lines = output.splitlines()
         no_pre = dropwhile(lambda l:' % fs' not in l, lines)
-        no_post = takewhile(lambda l:'(Steiner Minimal' not in l, no_pre)
+        no_post = takewhile(lambda l:'Euclidean SMT' not in l, no_pre)
         filter_comments = ifilter(lambda l: ' % fs' not in l, no_post)
         arcs = [l.split()[:4] for l in filter_comments]
         return arcs


### PR DESCRIPTION
This project was built for Geosteiner v3 or v3.1. With the most recent
version (5.0.1) the output of bb has had a breaking change from the
nomenclature of "steiner minimal" to "Euclidean SMT". This results in
the script including extra lines from the output that do not match the
expected structure.
- Replaced '(Steiner Minimal' in line 18 with 'Euclidean SMT'
